### PR TITLE
Avoid over highlighting REMARK commands

### DIFF
--- a/syntax/sql.vim
+++ b/syntax/sql.vim
@@ -164,7 +164,7 @@ syn keyword sqlTodo         contained DEBUG FIXME NOTE TODO XXX
 " Comments
 syn region sqlComment       start="/\*"  end="\*/" contains=sqlTodo
 syn match  sqlComment       "--.*$" contains=sqlTodo
-syn match  sqlComment       "rem.*$" contains=sqlTodo
+syn match  sqlComment       "\(^\|\s\)rem.*$" contains=sqlTodo
 
 " Mark correct paren use. Different colors for different purposes.
 syn region  sqlParens       transparent matchgroup=sqlParen start="(" end=")"


### PR DESCRIPTION
Adjust syntax to only highlight REMARK commands which:
- begin the line
- are preceded by whitespace

Before the highlighting would incorrectly highlight columns containing
the substring "rem" as a SQL comment:

``` sql
SELECT
  posts.remarks
     -- ^^^^^^^ was incorrectly highlighted as a comment
FROM posts
```
